### PR TITLE
Proposal for proposal workflow

### DIFF
--- a/000-template.rst
+++ b/000-template.rst
@@ -1,0 +1,56 @@
+**************************
+NEP-000: Proposal template
+**************************
+
+=================  ==================================
+Stage              Idea -> In progress -> Implemented
+Proposed by        Your name <your@email.com>
+Approved by
+Implemented by
+Completion date
+Implemented in
+=================  ==================================
+
+Context
+=======
+
+Describe the part of the ecosystem you aim to enhance.
+Why is this enhancement needed?
+
+Proposal
+========
+
+Give a short summary of your proposal.
+What are you proposing?
+
+Details
+=======
+
+Provide additional details in this section.
+While you should keep other sections short,
+feel free to use as much space as you want here.
+
+You can make additional sections
+--------------------------------
+
+Which can include source code::
+
+  "like this!"
+
+And references to `external resources <https://github.com/nengo/>`_.
+
+Pros and cons
+=============
+
+No proposal is perfect.
+In order to best review a proposal,
+please provide:
+
+* A list of pros
+
+And:
+
+* A list of cons
+
+These lists help maintainers evaluate the proposal.
+Maintainers may add to these lists during the review process.

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,90 @@
+***************************
+Nengo enhancement proposals
+***************************
+
+This repository contains proposals for enhancements
+to the Nengo ecosystem,
+dubbed Nengo Enhancement Proposals or NEPs [1]_.
+
+.. [1] Inspired by Python's `PEPs <https://www.python.org/dev/peps/>`_
+       and Jupyter's `JEPs <https://github.com/jupyter/enhancement-proposals>`_.
+
+NEPs are a way to propose and discuss changes that will touch
+multiple projects in the Nengo ecosystem,
+or require a large change to one project.
+NEPs allow Nengo developers to collaboratively
+propose and evaluate ideas
+before going through a lot of effort implementing them,
+and without cluttering up the issue tracker
+of individual projects.
+They also allow us to have a rough roadmap
+of upcoming changes to the Nengo ecosystem.
+
+Making a proposal
+=================
+
+To propose a new Nengo enhancement,
+make a pull request on this repository
+adding a reStructuredText file [2]_
+with the proposal.
+Your reStructedText file should follow
+the format of ``000-template.rst`` with
+all of the template text replaced with your proposal.
+
+.. [2] reStructuredText is used over other markup formats
+       as it can easily be included in Sphinx documentation.
+
+Note that, in addition to prose,
+there is a table of metadata at the start
+of each NEP. Most of the steps below
+involved updating that metadata.
+
+Review process
+==============
+
+Each NEP goes through a series of stages.
+In most cases, a pull request is used for each stage transition.
+While anyone can make a proposal
+and comment on it,
+only Nengo maintainers can approve stage transitions.
+
+The stages are as follows:
+
+1. NEPs marked as **idea** are enhancements that we wish to make,
+   but are not yet being worked on.
+
+   When you first open your proposal PR, it is in the idea stage.
+   In this stage, maintainers and developers will evaluate your proposal,
+   suggest additional pros and cons, and propose alternative solutions.
+
+   Once discussion settles down, a maintainer will choose to either
+   reject the proposal by closing the PR unmerged,
+   or will approve it by merging the PR.
+
+2. NEPs marked as **in progress** are enhancements currently being worked.
+
+   Developers can offer to implement approved ideas
+   by making a PR that fills in their name as
+   the proposed implementer,
+   and provides an estimated completion date.
+   The completion date is not a hard deadline,
+   but it helps maintainers keep track
+   of what is currently being worked on,
+   and what has been abandoned.
+
+   If a maintainer thinks that the developer is up to the task
+   and that the completion date is reasonable,
+   they will merge the PR.
+
+3. NEPs marked as **implemented** are finalized enhancements
+   with associated pull requests on Nengo repositories.
+
+   The PR should update the completion date and
+   point to the merged PRs.
+
+Note that the PRs coming out of these proposals
+go through normal review processes,
+and as a result could be rejected
+even if the proposal was accepted.
+In these cases, the proposal will be
+reverted from **in progress** to **idea**.


### PR DESCRIPTION
There are lots of old issues in the Nengo repository that are good ideas, but have not been touched for years, in part because they're big changes that might touch multiple repositories. At the most recent dev meeting, we decided that moving them to a repository for "ideas" (akin to [modelling-ideas](https://github.com/ctn-waterloo/modelling_ideas/issues)) would be a good way to move these issues somewhere that we can keep track of them, but keep them from cluttering the main issues lists.

This PR is my proposal for a workflow for this, similar to the [PEP](https://www.python.org/dev/peps/) and [JEP](https://github.com/jupyter/enhancement-proposals) workflows, but hopefully a bit simpler. I also made [labels](https://github.com/nengo/enhancement_proposals/labels) to support tagging PRs according to this workflow.

Sidenote: as opposed to https://github.com/ctn-waterloo/modelling_ideas, this PR proposes to keep proposals in files (RST files) so that they can be included in https://github.com/nengo/nengo.github.io easily.
